### PR TITLE
Prevent unmount errors when mount points do not exist

### DIFF
--- a/hetzner-debian10-zfs-setup.sh
+++ b/hetzner-debian10-zfs-setup.sh
@@ -407,7 +407,9 @@ function unmount_and_export_fs {
   print_step_info_header
 
   for virtual_fs_dir in dev sys proc; do
-    umount --recursive --force --lazy "$c_zfs_mount_dir/$virtual_fs_dir"
+    if [[ -d "$c_zfs_mount_dir/$virtual_fs_dir" ]] && mountpoint -q "$c_zfs_mount_dir/$virtual_fs_dir"; then
+      umount --recursive --force --lazy "$c_zfs_mount_dir/$virtual_fs_dir"
+    fi
   done
 
   local max_unmount_wait=5

--- a/hetzner-debian11-zfs-setup.sh
+++ b/hetzner-debian11-zfs-setup.sh
@@ -408,7 +408,9 @@ function unmount_and_export_fs {
   print_step_info_header
 
   for virtual_fs_dir in dev sys proc; do
-    umount --recursive --force --lazy "$c_zfs_mount_dir/$virtual_fs_dir"
+    if [[ -d "$c_zfs_mount_dir/$virtual_fs_dir" ]] && mountpoint -q "$c_zfs_mount_dir/$virtual_fs_dir"; then
+      umount --recursive --force --lazy "$c_zfs_mount_dir/$virtual_fs_dir"
+    fi
   done
 
   local max_unmount_wait=5

--- a/hetzner-debian12-zfs-setup.sh
+++ b/hetzner-debian12-zfs-setup.sh
@@ -426,7 +426,9 @@ function unmount_and_export_fs {
   print_step_info_header
 
   for virtual_fs_dir in dev sys proc; do
-    umount --recursive --force --lazy "$c_zfs_mount_dir/$virtual_fs_dir"
+    if [[ -d "$c_zfs_mount_dir/$virtual_fs_dir" ]] && mountpoint -q "$c_zfs_mount_dir/$virtual_fs_dir"; then
+      umount --recursive --force --lazy "$c_zfs_mount_dir/$virtual_fs_dir"
+    fi
   done
 
   local max_unmount_wait=5

--- a/hetzner-ubuntu18-zfs-setup.sh
+++ b/hetzner-ubuntu18-zfs-setup.sh
@@ -374,7 +374,9 @@ function unmount_and_export_fs {
   print_step_info_header
 
   for virtual_fs_dir in dev sys proc; do
-    umount --recursive --force --lazy "$c_zfs_mount_dir/$virtual_fs_dir"
+    if [[ -d "$c_zfs_mount_dir/$virtual_fs_dir" ]] && mountpoint -q "$c_zfs_mount_dir/$virtual_fs_dir"; then
+      umount --recursive --force --lazy "$c_zfs_mount_dir/$virtual_fs_dir"
+    fi
   done
 
   local max_unmount_wait=5

--- a/hetzner-ubuntu20-zfs-setup.sh
+++ b/hetzner-ubuntu20-zfs-setup.sh
@@ -374,7 +374,9 @@ function unmount_and_export_fs {
   print_step_info_header
 
   for virtual_fs_dir in dev sys proc; do
-    umount --recursive --force --lazy "$c_zfs_mount_dir/$virtual_fs_dir"
+    if [[ -d "$c_zfs_mount_dir/$virtual_fs_dir" ]] && mountpoint -q "$c_zfs_mount_dir/$virtual_fs_dir"; then
+      umount --recursive --force --lazy "$c_zfs_mount_dir/$virtual_fs_dir"
+    fi
   done
 
   local max_unmount_wait=5

--- a/hetzner-ubuntu22-zfs-setup.sh
+++ b/hetzner-ubuntu22-zfs-setup.sh
@@ -374,7 +374,9 @@ function unmount_and_export_fs {
   print_step_info_header
 
   for virtual_fs_dir in dev sys proc; do
-    umount --recursive --force --lazy "$c_zfs_mount_dir/$virtual_fs_dir"
+    if [[ -d "$c_zfs_mount_dir/$virtual_fs_dir" ]] && mountpoint -q "$c_zfs_mount_dir/$virtual_fs_dir"; then
+      umount --recursive --force --lazy "$c_zfs_mount_dir/$virtual_fs_dir"
+    fi
   done
 
   local max_unmount_wait=5


### PR DESCRIPTION
## Summary
- improve unmount_and_export_fs so it only unmounts existing mountpoints

## Testing
- `./ci/run_shellcheck.sh`

------
https://chatgpt.com/codex/tasks/task_b_686e9aa9299083219fe2b989298774db